### PR TITLE
Add named exports

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -1,4 +1,4 @@
-global.step = function(msg, fn) {
+module.exports.step = global.step = function(msg, fn) {
 
   function markRemainingTestsAndSubSuitesAsPending(currentTest) {
       var tests = currentTest.parent.tests;
@@ -82,6 +82,6 @@ global.step = function(msg, fn) {
 
 };
 
-global.xstep = function(msg, fn) {
+module.exports.xstep = global.xstep = function(msg, fn) {
   it(msg, null);
 };

--- a/test/export.js
+++ b/test/export.js
@@ -1,0 +1,24 @@
+var step = require('../lib/step').step;
+var xstep = require('../lib/step').xstep;
+
+describe('export', function() {
+
+  describe('it()', function() {
+
+    it('is executed', function() {
+    });
+
+    xit('is not executed');
+
+  });
+
+  describe('step()', function() {
+
+    step('is executed', function() {
+    });
+
+    xstep('is not executed');
+
+  });
+
+});

--- a/test/export.txt
+++ b/test/export.txt
@@ -1,0 +1,8 @@
+1..4
+ok 1 export it() is executed
+ok 2 export it() is not executed # SKIP -
+ok 3 export step() is executed
+ok 4 export step() is not executed # SKIP -
+# tests 2
+# pass 2
+# fail 0


### PR DESCRIPTION
Closes #11.
This allow per-file inclusion instead of forcing a global require. And works nicely with Babel and ES modules:

```js
import { step, xstep } from 'mocha-steps';
```