### PR TITLE
add minor steps

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -85,3 +85,7 @@ module.exports.step = global.step = function(msg, fn) {
 module.exports.xstep = global.xstep = function(msg, fn) {
   it(msg, null);
 };
+
+module.exports.mstep = global.mstep = function(msg, fn) {
+  it(msg, fn);
+};


### PR DESCRIPTION
why not to add minor steps (such as notification check) that won't skip next steps if it failed. Yes we can use 'it' instead, but 'mstep'  (or any other name), I think, is common-likely.