### PR TITLE
return result of it() (=> allow step().timeout())

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -75,15 +75,15 @@ module.exports.step = global.step = function(msg, fn) {
   }
 
   if (fn == null) {
-    it(msg);
+    return it(msg);
   } else if (fn.length === 0) {
-    it(msg, sync);
+    return it(msg, sync);
   } else {
-    it(msg, async);
+    return it(msg, async);
   }
 
 };
 
 module.exports.xstep = global.xstep = function(msg, fn) {
-  it(msg, null);
+  return it(msg, null);
 };

--- a/test/return_it.js
+++ b/test/return_it.js
@@ -1,0 +1,35 @@
+require('../lib/step');
+
+function wait(ms) {
+  return new Promise(function(resolve, reject) {
+    setTimeout(resolve, ms);
+  })
+}
+
+describe('return it()', function() {
+
+  describe('it()', () => {
+
+    it('should timeout', function() {
+      return wait(10); 
+    }).timeout(5);
+
+    it('should succeed', function() {
+      return wait(5);
+    }).timeout(10);
+
+  })
+
+  describe('step()', () => {
+
+    step('should timeout', function() {
+      return wait(10); 
+    }).timeout(5);
+
+    step('should succeed', function() {
+      return wait(5);
+    }).timeout(10);
+
+  })
+
+})

--- a/test/return_it.txt
+++ b/test/return_it.txt
@@ -1,0 +1,8 @@
+1..4
+not ok 1 return it() it() should timeout
+ok 2 return it() it() should succeed
+not ok 3 return it() step() should timeout
+ok 4 return it() step() should succeed
+# tests 4
+# pass 2
+# fail 2


### PR DESCRIPTION
Hey,

Was hoping you'd accept this - if we `return it()` instead of just `it()` in `step()`, then this allows users to do
```
step('message', () => {
  // ... something slow
}).timeout(10000)
```, 

mirroring the use of `it().timeout()` that is part of mocha's API, along with anything else in the entirely undocumented [Runnable](https://github.com/mochajs/mocha/blob/master/lib/runnable.js) interface.