### PR TITLE
change the test.body to the string of the test function

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -26,6 +26,7 @@ module.exports.step = global.step = function(msg, fn) {
     var context = this;
 
     try {
+      context.test.body = fn.toString();
       var promise = fn.call(context);
       if (promise != null && promise.then != null && promise.catch != null) {
         return promise.catch(function(err) {
@@ -58,6 +59,7 @@ module.exports.step = global.step = function(msg, fn) {
     process.addListener('uncaughtException', onError);
 
     try {
+      context.test.body = fn.toString();
       fn.call(context, function(err) {
         if (err) {
           onError();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-steps",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-steps",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Sequential scenarios for Mocha",
   "author": "Romain Prieto",
   "keywords": [


### PR DESCRIPTION
A small fix...
Normally, Mocha sets the "test.body" to the code in the test function (as a string). We are using Mochawesome reports which display this string in the report to show you what the code was in each test-step. 

Problem:
When we use Mocha-steps, we find that the test.body is set to the code in either the sync or async function because these are functions were passed to the "it" instead of the actual test-step function.

Fix:
I've resolved this by changing the test.body to be a string of the test-step function. I've run the tests on travis and checked that it resolves issue for all test function types. Many thanks, Ian
