### PR TITLE
restore the runnable.body to the test-steps function

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -24,6 +24,7 @@ module.exports.step = global.step = function(msg, fn) {
   function sync() {
 
     var context = this;
+    context.test.body = fn.toString();
 
     try {
       var promise = fn.call(context);
@@ -49,6 +50,7 @@ module.exports.step = global.step = function(msg, fn) {
   function async(done) {
 
     var context = this;
+    context.test.body = fn.toString();
 
     function onError() {
       markRemainingTestsAndSubSuitesAsPending(context.test);

--- a/test/body.js
+++ b/test/body.js
@@ -1,0 +1,32 @@
+require('../lib/step');
+
+function sync() {
+  if (this.runnable().body !== sync.toString())
+    throw new Error('body incorrect');
+}
+
+function async(done) {
+  if (this.runnable().body !== async.toString())
+    throw new Error('body incorrect');
+  done();
+}
+
+describe('body', function() {
+
+  describe('it()', () => {
+
+    it('synchronous', sync);
+
+    it('async', async);
+
+  });
+
+  describe('step()', () => {
+
+    step('synchronous', sync);
+
+    step('async', async);
+
+  });
+
+});

--- a/test/body.txt
+++ b/test/body.txt
@@ -1,0 +1,8 @@
+1..4
+ok 1 body it() synchronous
+ok 2 body it() async
+ok 3 body step() synchronous
+ok 4 body step() async
+# tests 4
+# pass 4
+# fail 0


### PR DESCRIPTION
Hi,
Within Mocha, the [test.body](https://mochajs.org/api/runnable.js.html) contains the test-step's JS code as a string. The purpose of this is to allow reporters such as Mochawesome to display the test-steps' JS code within the report.

Since mocha-steps is using 2 intermediary functions (sync & async), Mocha is now setting the .body to the JS code within these functions. For example, the report should display the test step's code such as this:

```
function() {
  expect(1).to.equal(1);
}
```

But, instead it always appears like this, because Mocha thinks this function is the test-step function:
```
function sync() {
  var context = this;
  context.test.body = fn.toString();
  try {
    var promise = fn.call(context);
    if (promise != null && promise.then != null && promise.catch != null) {
      return promise.catch(function(err) {
        markRemainingTestsAndSubSuitesAsPending(context.test);
        throw err;
      });
    } else {
      return promise;
    }
  } catch (ex) {
    markRemainingTestsAndSubSuitesAsPending(context.test);
    throw ex;
  }
}
```

This has easily been resolved by setting the context.body to the actual test-step's fn.string(). This is confirmed working with a test. I'd really appreciate it if you could release a new version with this fix in. Many thanks, Ian