### PR TITLE
Correctly handle timeouts when skipping subsequent steps

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -25,17 +25,24 @@ module.exports.step = global.step = function(msg, fn) {
 
     var context = this;
 
+    var timeout = setTimeout(function() {
+      markRemainingTestsAndSubSuitesAsPending(context.test)
+    }, context.timeout())
+
     try {
       var promise = fn.call(context);
       if (promise != null && promise.then != null && promise.catch != null) {
         return promise.catch(function(err) {
+          clearTimeout(timeout)
           markRemainingTestsAndSubSuitesAsPending(context.test);
           throw err;
         });
       } else {
+        clearTimeout(timeout)
         return promise;
       }
     } catch (ex) {
+      clearTimeout(timeout)
       markRemainingTestsAndSubSuitesAsPending(context.test);
       throw ex;
     }
@@ -50,6 +57,10 @@ module.exports.step = global.step = function(msg, fn) {
 
     var context = this;
 
+    var timeout = setTimeout(function() {
+      markRemainingTestsAndSubSuitesAsPending(context.test)
+    }, context.timeout())
+
     function onError() {
       markRemainingTestsAndSubSuitesAsPending(context.test);
       process.removeListener('uncaughtException', onError);
@@ -59,6 +70,8 @@ module.exports.step = global.step = function(msg, fn) {
 
     try {
       fn.call(context, function(err) {
+        clearTimeout(timeout)
+
         if (err) {
           onError();
           done(err);
@@ -68,6 +81,8 @@ module.exports.step = global.step = function(msg, fn) {
         }
       });
     } catch(ex) {
+      clearTimeout(timeout)
+
       onError();
       throw ex;
     }

--- a/test/async_callback.js
+++ b/test/async_callback.js
@@ -19,9 +19,9 @@ describe('async callback', function() {
     });
 
     describe('sub-suite', function() {
-        it('D', function(done) {
-          setTimeout(done, 50);
-        });
+      it('D', function(done) {
+        setTimeout(done, 50);
+      });
     });
 
   });
@@ -43,9 +43,9 @@ describe('async callback', function() {
     });
 
     describe('sub-suite', function() {
-        step('D', function(done) {
-          setTimeout(done, 50);
-        });
+      step('D', function(done) {
+        setTimeout(done, 50);
+      });
     });
 
   });

--- a/test/async_exception.js
+++ b/test/async_exception.js
@@ -17,9 +17,9 @@ describe('async exception', function() {
     });
 
     describe('sub-suite', function() {
-        it('D', function(done) {
-          setTimeout(done, 50);
-        });
+      it('D', function(done) {
+        setTimeout(done, 50);
+      });
     });
 
   });
@@ -39,9 +39,9 @@ describe('async exception', function() {
     });
 
     describe('sub-suite', function() {
-        step('D', function(done) {
-          setTimeout(done, 50);
-        });
+      step('D', function(done) {
+        setTimeout(done, 50);
+      });
     });
 
   });

--- a/test/events.js
+++ b/test/events.js
@@ -52,9 +52,9 @@ describe('events', function() {
     });
 
     describe('sub-suite', function() {
-        step('D', function(done) {
-          setTimeout(done, 50);
-        });
+      step('D', function(done) {
+        setTimeout(done, 50);
+      });
     });
 
   });

--- a/test/return_it.js
+++ b/test/return_it.js
@@ -11,7 +11,7 @@ describe('return it()', function() {
   describe('it()', () => {
 
     it('should timeout', function() {
-      return wait(10); 
+      return wait(10);
     }).timeout(5);
 
     it('should succeed', function() {
@@ -23,10 +23,10 @@ describe('return it()', function() {
   describe('step()', () => {
 
     step('should timeout', function() {
-      return wait(10); 
+      return wait(10);
     }).timeout(5);
 
-    step('should succeed', function() {
+    step('should be skipped', function() {
       return wait(5);
     }).timeout(10);
 

--- a/test/return_it.txt
+++ b/test/return_it.txt
@@ -2,7 +2,7 @@
 not ok 1 return it() it() should timeout
 ok 2 return it() it() should succeed
 not ok 3 return it() step() should timeout
-ok 4 return it() step() should succeed
-# tests 4
-# pass 2
+ok 4 return it() step() should be skipped # SKIP -
+# tests 3
+# pass 1
 # fail 2

--- a/test/timeouts.js
+++ b/test/timeouts.js
@@ -1,53 +1,39 @@
 require('../lib/step');
 
-describe('async exception in callback', function() {
-
+describe('timeouts should fail subsequent steps', function() {
   describe('it()', function() {
+    this.timeout(100)
 
     it('A', function(done) {
-      setTimeout(done, 50);
+      setTimeout(done, 150);
     });
 
     it('B', function(done) {
-      setTimeout(function() {
-        throw new Error('failed');
-      }, 50);
-    });
-
-    it('C', function(done) {
       setTimeout(done, 50);
     });
 
     describe('sub-suite', function() {
-      it('D', function(done) {
+      it('C', function(done) {
         setTimeout(done, 50);
       });
     });
-
   });
 
   describe('step()', function() {
+    this.timeout(100)
 
     step('A', function(done) {
-      setTimeout(done, 50);
+      setTimeout(done, 150);
     });
 
     step('B', function(done) {
-      setTimeout(function() {
-        throw new Error('failed');
-      }, 50);
-    });
-
-    step('C', function(done) {
       setTimeout(done, 50);
     });
 
     describe('sub-suite', function() {
-      step('D', function(done) {
+      step('C', function(done) {
         setTimeout(done, 50);
       });
     });
-
   });
-
 });

--- a/test/timeouts.txt
+++ b/test/timeouts.txt
@@ -1,0 +1,10 @@
+1..6
+not ok 1 timeouts should fail subsequent steps it() A
+ok 2 timeouts should fail subsequent steps it() B
+ok 3 timeouts should fail subsequent steps it() sub-suite C
+not ok 4 timeouts should fail subsequent steps step() A
+ok 5 timeouts should fail subsequent steps step() B # SKIP -
+ok 6 timeouts should fail subsequent steps step() sub-suite C # SKIP -
+# tests 4
+# pass 2
+# fail 2

--- a/test/ts-definitions.ts
+++ b/test/ts-definitions.ts
@@ -9,4 +9,5 @@ describe('ts-definitions', () => {
   xstep('xstep', () => {
     throw new Error("Should be ignored")
   });
+
 });


### PR DESCRIPTION
This is achieved by running the `markRemainingTestsAndSubSuitesAsPending` function
inside a setTimeout using the current context's timeout value.

Fixes: rprieto/mocha-steps#17